### PR TITLE
Add authentication with AWS amplify

### DIFF
--- a/amplify/backend/auth/thewinjarae8a92e4/cli-inputs.json
+++ b/amplify/backend/auth/thewinjarae8a92e4/cli-inputs.json
@@ -1,0 +1,45 @@
+{
+  "version": "1",
+  "cognitoConfig": {
+    "identityPoolName": "thewinjarae8a92e4_identitypool_ae8a92e4",
+    "allowUnauthenticatedIdentities": false,
+    "resourceNameTruncated": "thewinae8a92e4",
+    "userPoolName": "thewinjarae8a92e4_userpool_ae8a92e4",
+    "autoVerifiedAttributes": [
+      "email"
+    ],
+    "mfaConfiguration": "OFF",
+    "mfaTypes": [
+      "SMS Text Message"
+    ],
+    "smsAuthenticationMessage": "Your authentication code is {####}",
+    "smsVerificationMessage": "Your verification code is {####}",
+    "emailVerificationSubject": "Your verification code",
+    "emailVerificationMessage": "Your verification code is {####}",
+    "defaultPasswordPolicy": false,
+    "passwordPolicyMinLength": 8,
+    "passwordPolicyCharacters": [],
+    "requiredAttributes": [
+      "email"
+    ],
+    "aliasAttributes": [],
+    "userpoolClientGenerateSecret": false,
+    "userpoolClientRefreshTokenValidity": 30,
+    "userpoolClientWriteAttributes": [
+      "email"
+    ],
+    "userpoolClientReadAttributes": [
+      "email"
+    ],
+    "userpoolClientLambdaRole": "thewinae8a92e4_userpoolclient_lambda_role",
+    "userpoolClientSetAttributes": false,
+    "sharedId": "ae8a92e4",
+    "resourceName": "thewinjarae8a92e4",
+    "authSelections": "identityPoolAndUserPool",
+    "useDefault": "default",
+    "userPoolGroupList": [],
+    "serviceName": "Cognito",
+    "usernameCaseSensitive": false,
+    "useEnabledMfas": true
+  }
+}

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -1,1 +1,28 @@
-{}
+{
+  "auth": {
+    "thewinjarae8a92e4": {
+      "service": "Cognito",
+      "providerPlugin": "awscloudformation",
+      "dependsOn": [],
+      "customAuth": false,
+      "frontendAuthConfig": {
+        "socialProviders": [],
+        "usernameAttributes": [],
+        "signupAttributes": [
+          "EMAIL"
+        ],
+        "passwordProtectionSettings": {
+          "passwordPolicyMinLength": 8,
+          "passwordPolicyCharacters": []
+        },
+        "mfaConfiguration": "OFF",
+        "mfaTypes": [
+          "SMS"
+        ],
+        "verificationMechanisms": [
+          "EMAIL"
+        ]
+      }
+    }
+  }
+}

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,1 +1,13 @@
-export type AmplifyDependentResourcesAttributes = {}
+export type AmplifyDependentResourcesAttributes = {
+    "auth": {
+        "thewinjarae8a92e4": {
+            "IdentityPoolId": "string",
+            "IdentityPoolName": "string",
+            "UserPoolId": "string",
+            "UserPoolArn": "string",
+            "UserPoolName": "string",
+            "AppClientIDWeb": "string",
+            "AppClientID": "string"
+        }
+    }
+}

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -10,6 +10,11 @@
       "StackName": "amplify-thewinjar-dev-213816",
       "StackId": "arn:aws:cloudformation:us-east-1:210313767167:stack/amplify-thewinjar-dev-213816/a76acf40-4036-11ed-833c-12689b2b92c3",
       "AmplifyAppId": "dyu8p994vb3rd"
+    },
+    "categories": {
+      "auth": {
+        "thewinjarae8a92e4": {}
+      }
     }
   }
 }

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -2,15 +2,17 @@ import React from "react";
 import "../App.css";
 import AddWinsPage from "./Pages/AddWinsPage.";
 import PageLayoutShell from "./Layouts/PageLayoutShell.";
+import { withAuthenticator, Heading } from "@aws-amplify/ui-react";
+import "@aws-amplify/ui-react/styles.css";
 
-function App() {
+function App({ signOut, user }: any) {
   return (
     <div className="App">
-      <PageLayoutShell>
-        <AddWinsPage />
+      <PageLayoutShell signOut={signOut} user={user}>
+        <AddWinsPage user={user} />
       </PageLayoutShell>
     </div>
   );
 }
 
-export default App;
+export default withAuthenticator(App);

--- a/src/App/Layouts/PageLayoutShell..tsx
+++ b/src/App/Layouts/PageLayoutShell..tsx
@@ -15,10 +15,7 @@ import {
   typographySecondary,
 } from "../../styles";
 import SentimentVerySatisfiedOutlinedIcon from "@mui/icons-material/SentimentVerySatisfiedOutlined";
-
-export interface PageLayoutShellProps {
-  children: React.ReactNode;
-}
+import { Button } from "@aws-amplify/ui-react";
 
 const HeaderStyle = `${typographyPrimaryAccent} ${fontSizeXLarge} ${fontWeightMedium} px-12 py-12`;
 const IconStyle = `ml-1`;
@@ -31,7 +28,16 @@ const ContainerStyle = classnames(
 
 const FooterStyle = `${typographySecondary} ${fontSizeExtraSmall} py-12 px-12`;
 const FooterLinkStyle = `${linkFooter}`;
+
+export interface PageLayoutShellProps {
+  children: React.ReactNode;
+  user: any;
+  signOut: () => any;
+}
+
 export const PageLayoutShell: React.FC<PageLayoutShellProps> = ({
+  user,
+  signOut,
   children,
 }) => {
   return (
@@ -42,6 +48,7 @@ export const PageLayoutShell: React.FC<PageLayoutShellProps> = ({
       </header>
       {children}
       <footer className={FooterStyle}>
+        <Button onClick={signOut}>sign out</Button>
         <a
           href="https://www.nicoleis.xyz"
           target="_blank"

--- a/src/App/Pages/AddWinsPage..tsx
+++ b/src/App/Pages/AddWinsPage..tsx
@@ -11,8 +11,6 @@ import {
 import TextFieldInput from "../../components/TextField.";
 import { ButtonComponent } from "../../components/Button";
 
-export interface AddWinsPageProps {}
-
 const ContainerStyle = classnames(
   display("flex"),
   flexDirection("flex-col"),
@@ -21,10 +19,14 @@ const ContainerStyle = classnames(
 );
 const HeaderStyle = `${textHeading}`;
 
-export const AddWinsPage: React.FC<AddWinsPageProps> = () => {
+export interface AddWinsPageProps {
+  user: any;
+}
+
+export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
   return (
     <div className={ContainerStyle}>
-      <p className={HeaderStyle}>welcome to your win jar!</p>
+      <p className={HeaderStyle}>hello {user.username}!</p>
       <TextFieldInput label={"tell me your win ✨"} isMultiline />
       <ButtonComponent label={"add to win jar"} endIcon={<AddOutlinedIcon />} />
     </div>

--- a/src/stories/3-Features/AddWinsPage..stories.tsx
+++ b/src/stories/3-Features/AddWinsPage..stories.tsx
@@ -5,4 +5,4 @@ export default {
   title: "3-Features/AddWins",
 };
 
-export const AddWinsPageStory = () => <AddWinsPage></AddWinsPage>;
+export const AddWinsPageStory = () => <AddWinsPage user={"cool person"} />;


### PR DESCRIPTION
Added authentication with Amplify, which uses Amazon Cognito as the authentication provider. 
- Created authenticate service with the Amplify CLI
- Deployed the service 
- Added the authenticator UI components to the app to allow user to sign up, sign in and sign out

![image](https://user-images.githubusercontent.com/70478809/193147932-6a87f722-9aa7-42d0-b6c1-6f9f65fc2b8f.png)
![image](https://user-images.githubusercontent.com/70478809/193148015-315d35ee-0049-49c5-a4ad-1827930ff5a9.png)