### PR TITLE
Improve the add wins user experience

### DIFF
--- a/src/App/Layouts/Footer.tsx
+++ b/src/App/Layouts/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SecondaryButton } from "../../components/Button";
+import { LinkButton } from "../../components/Button";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import * as styles from "../../styles";
 
@@ -13,7 +13,7 @@ export interface FooterProps {
 export const Footer: React.FC<FooterProps> = ({ signOut }) => {
   return (
     <footer className={FooterStyle}>
-      <SecondaryButton
+      <LinkButton
         label={"sign out"}
         onClick={signOut}
         endIcon={<LogoutOutlinedIcon />}

--- a/src/App/Layouts/PageLayoutShell.tsx
+++ b/src/App/Layouts/PageLayoutShell.tsx
@@ -1,19 +1,14 @@
 import React from "react";
-import {
-  classnames,
-  display,
-  flexDirection,
-  height,
-  justifyContent,
-} from "tailwindcss-classnames";
+import * as classes from "tailwindcss-classnames";
 import Header from "./Header";
 import Footer from "./Footer";
+import { classnames } from "tailwindcss-classnames";
 
 const ContainerStyle = classnames(
-  display("flex"),
-  flexDirection("flex-col"),
-  justifyContent("justify-between"),
-  height("h-screen")
+  classes.display("flex"),
+  classes.flexDirection("flex-col"),
+  classes.justifyContent("justify-between"),
+  classes.height("h-screen")
 );
 
 export interface PageLayoutShellProps {
@@ -30,7 +25,7 @@ export const PageLayoutShell: React.FC<PageLayoutShellProps> = ({
   return (
     <div className={ContainerStyle}>
       <Header />
-      {children}
+      <main>{children}</main>
       <Footer signOut={signOut} />
     </div>
   );

--- a/src/App/Pages/AddWinsPage.tsx
+++ b/src/App/Pages/AddWinsPage.tsx
@@ -147,9 +147,7 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
                         secondary={
                           <>
                             <p className={DateStyle}>
-                              {new Date(win.createdAt).toLocaleDateString(
-                                "en-US"
-                              )}
+                              {new Date(win.createdAt).toLocaleDateString()}
                             </p>
                           </>
                         }

--- a/src/App/Pages/AddWinsPage.tsx
+++ b/src/App/Pages/AddWinsPage.tsx
@@ -93,8 +93,10 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
         authMode: "AMAZON_COGNITO_USER_POOLS",
         variables: { input: data },
       });
-    } catch {}
-
+      handleAddWinClick();
+    } catch (err) {
+      console.log(err);
+    }
     fetchWins();
     event.target?.reset();
   }
@@ -112,10 +114,12 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
   const [isSuccessAlertVisible, setIsSuccessAlertVisible] =
     React.useState(false);
   const [alertText, setAlertText] = React.useState("");
+  const [winText, setWinText] = useState("");
 
   const handleAddWinClick = () => {
     setAlertText("Successfully added to your win jar! 🎉");
     setIsSuccessAlertVisible(true);
+    setWinText("");
   };
 
   const handleDeleteWinClick = () => {
@@ -144,12 +148,14 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
               label={"tell me your win ✨"}
               isMultiline
               name={"winText"}
+              value={winText}
+              onChange={(event) => setWinText(event.target.value)}
             />
             <PrimaryButton
               label={"add to win jar"}
               endIcon={<AddOutlinedIcon />}
               type={"submit"}
-              onClick={handleAddWinClick}
+              disabled={!winText}
             />
             <Snackbar
               open={isSuccessAlertVisible}

--- a/src/App/Pages/AddWinsPage.tsx
+++ b/src/App/Pages/AddWinsPage.tsx
@@ -36,11 +36,10 @@ const WinListStyle = classnames(
   classes.display("flex"),
   classes.flexDirection("flex-col"),
   classes.alignItems("items-start"),
-  classes.width("w-full"),
   classes.gap("gap-8")
 );
 
-const WinStyle = classnames(
+const WinItemStyle = classnames(
   classes.display("flex"),
   classes.alignItems("items-start"),
   classes.justifyContent("justify-between")
@@ -48,16 +47,15 @@ const WinStyle = classnames(
 
 const WinContentStyle = classnames(
   classes.display("flex"),
-  classes.flexWrap("flex-wrap"),
   classes.flexDirection("flex-col"),
-  classes.alignItems("items-start"),
-  classes.justifyContent("justify-start"),
-  classes.width("w-96"),
+  classes.width("w-64"),
+  classes.width("md:w-96"),
   classes.whitespace("whitespace-normal"),
-  classes.flex("flex-initial")
+  classes.overflow("overflow-hidden"),
+  classes.wordBreak("break-normal")
 );
 
-const WinTextStyle = `${styles.typographyPrimary} flex-initial`;
+const WinTextStyle = `${styles.typographyPrimary}`;
 const DateStyle = `${styles.typographySecondary} ${styles.fontSizeSmall}`;
 
 // style config for MUI modal
@@ -66,6 +64,7 @@ const modalStyle = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
+  minWidth: "30vw",
   maxWidth: "80vw",
   maxHeight: "80vh",
   borderRadius: "8px",
@@ -183,16 +182,25 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
           />
         </View>
         <View className={ContainerStyle}>
-          <Tooltip title="No wins yet">
-            <span>
-              <SecondaryButton
-                label={"open win jar"}
-                onClick={() => setIsWinJarOpen(true)}
-                disabled={!wins.length}
-                startIcon={<AutoAwesomeOutlinedIcon />}
-              />
-            </span>
-          </Tooltip>
+          {!wins.length ? (
+            <Tooltip title="No wins yet">
+              <span>
+                <SecondaryButton
+                  label={"open win jar"}
+                  onClick={() => setIsWinJarOpen(true)}
+                  disabled={!wins.length}
+                  startIcon={<AutoAwesomeOutlinedIcon />}
+                />
+              </span>
+            </Tooltip>
+          ) : (
+            <SecondaryButton
+              label={"open win jar"}
+              onClick={() => setIsWinJarOpen(true)}
+              disabled={!wins.length}
+              startIcon={<AutoAwesomeOutlinedIcon />}
+            />
+          )}
           <Modal
             open={isWinJarOpen}
             onClose={() => setIsWinJarOpen(false)}
@@ -210,12 +218,14 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
                   ) : (
                     wins
                       .map((win) => (
-                        <div key={win.id} className={WinStyle}>
+                        <div key={win.id} className={WinItemStyle}>
                           <div className={WinContentStyle}>
                             <span className={DateStyle}>
                               {new Date(win.createdAt).toLocaleDateString()}
                             </span>
-                            <span className={WinTextStyle}>{win.win_text}</span>
+                            <div className={WinTextStyle}>
+                              <span>{win.win_text}</span>
+                            </div>
                           </div>
                           <IconButton
                             aria-label="delete win"

--- a/src/App/Pages/AddWinsPage.tsx
+++ b/src/App/Pages/AddWinsPage.tsx
@@ -1,17 +1,11 @@
 import React, { useEffect, useState } from "react";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import DeleteIcon from "@mui/icons-material/Delete";
 import * as styles from "../../styles";
-import {
-  alignItems,
-  classnames,
-  display,
-  flexDirection,
-  gap,
-  justifyContent,
-  width,
-} from "tailwindcss-classnames";
+import * as classes from "tailwindcss-classnames";
 import TextFieldInput from "../../components/TextField";
-import { PrimaryButton } from "../../components/Button";
+import { PrimaryButton, SecondaryButton } from "../../components/Button";
 import { API } from "aws-amplify";
 import { listWins } from "../../graphql/queries";
 import {
@@ -19,37 +13,68 @@ import {
   deleteWin as deleteWinMutation,
 } from "../../graphql/mutations";
 import { View } from "@aws-amplify/ui-react";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { IconButton, Snackbar } from "@mui/material";
-import MuiAlert, { AlertProps } from "@mui/material/Alert";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
-import ListItemAvatar from "@mui/material/ListItemAvatar";
 
+import { Box, Fade, IconButton, Modal, Snackbar, Tooltip } from "@mui/material";
+import MuiAlert, { AlertProps } from "@mui/material/Alert";
+import { classnames } from "tailwindcss-classnames";
+
+const MainStyle = classnames(
+  classes.display("flex"),
+  classes.flexDirection("flex-col"),
+  classes.alignItems("items-center"),
+  classes.gap("gap-4")
+);
 const ContainerStyle = classnames(
-  display("flex"),
-  flexDirection("flex-col"),
-  alignItems("items-center"),
-  gap("gap-12")
+  classes.display("flex"),
+  classes.flexDirection("flex-col"),
+  classes.alignItems("items-center"),
+  classes.gap("gap-12")
 );
 const HeaderStyle = `${styles.textHeading}`;
 
 const WinListStyle = classnames(
-  display("flex"),
-  flexDirection("flex-col"),
-  alignItems("items-center")
+  classes.display("flex"),
+  classes.flexDirection("flex-col"),
+  classes.alignItems("items-start"),
+  classes.width("w-full"),
+  classes.gap("gap-8")
 );
 
 const WinStyle = classnames(
-  display("flex"),
-  flexDirection("flex-col"),
-  alignItems("items-center"),
-  justifyContent("justify-start"),
-  width("w-96")
+  classes.display("flex"),
+  classes.alignItems("items-start"),
+  classes.justifyContent("justify-between")
 );
 
-const DateStyle = `${styles.typographySecondary}`;
+const WinContentStyle = classnames(
+  classes.display("flex"),
+  classes.flexWrap("flex-wrap"),
+  classes.flexDirection("flex-col"),
+  classes.alignItems("items-start"),
+  classes.justifyContent("justify-start"),
+  classes.width("w-96"),
+  classes.whitespace("whitespace-normal"),
+  classes.flex("flex-initial")
+);
+
+const WinTextStyle = `${styles.typographyPrimary} flex-initial`;
+const DateStyle = `${styles.typographySecondary} ${styles.fontSizeSmall}`;
+
+// style config for MUI modal
+const modalStyle = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  maxWidth: "80vw",
+  maxHeight: "80vh",
+  borderRadius: "8px",
+  backgroundColor: "white",
+  boxShadow: 24,
+  p: 4,
+  overflowX: "none",
+  overflowY: "auto",
+};
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
   props,
@@ -64,6 +89,11 @@ export interface AddWinsPageProps {
 
 export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
   const [wins, setWins] = useState<any[]>([]);
+  const [isSuccessAlertVisible, setIsSuccessAlertVisible] =
+    React.useState(false);
+  const [alertText, setAlertText] = React.useState("");
+  const [winText, setWinText] = useState("");
+  const [isWinJarOpen, setIsWinJarOpen] = useState(false);
 
   useEffect(() => {
     fetchWins();
@@ -111,11 +141,6 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
     });
   }
 
-  const [isSuccessAlertVisible, setIsSuccessAlertVisible] =
-    React.useState(false);
-  const [alertText, setAlertText] = React.useState("");
-  const [winText, setWinText] = useState("");
-
   const handleAddWinClick = () => {
     setAlertText("Successfully added to your win jar! 🎉");
     setIsSuccessAlertVisible(true);
@@ -140,84 +165,89 @@ export const AddWinsPage: React.FC<AddWinsPageProps> = ({ user }) => {
 
   return (
     <>
-      <View>
-        <View as="form" onSubmit={createWin}>
-          <div className={ContainerStyle}>
-            <p className={HeaderStyle}>{`heeeey, great to see you! 👋`}</p>
-            <TextFieldInput
-              label={"tell me your win ✨"}
-              isMultiline
-              name={"winText"}
-              value={winText}
-              onChange={(event) => setWinText(event.target.value)}
-            />
-            <PrimaryButton
-              label={"add to win jar"}
-              endIcon={<AddOutlinedIcon />}
-              type={"submit"}
-              disabled={!winText}
-            />
-            <Snackbar
-              open={isSuccessAlertVisible}
-              autoHideDuration={6000}
-              onClose={handleAlertClose}
-            >
-              <Alert
-                onClose={handleAlertClose}
-                severity="success"
-                sx={{ width: "100%" }}
-              >
-                {alertText}
-              </Alert>
-            </Snackbar>
-          </div>
+      <View className={MainStyle}>
+        <View as="form" onSubmit={createWin} className={ContainerStyle}>
+          <p className={HeaderStyle}>{`heeeey, great to see you! 👋`}</p>
+          <TextFieldInput
+            label={"tell me your win ✨"}
+            isMultiline
+            name={"winText"}
+            value={winText}
+            onChange={(event) => setWinText(event.target.value)}
+          />
+          <PrimaryButton
+            label={"add to win jar"}
+            endIcon={<AddOutlinedIcon />}
+            type={"submit"}
+            disabled={!winText}
+          />
         </View>
-        <View margin="3rem 0">
-          <div className={WinListStyle}>
-            {wins.length === 0 ? (
-              <p className={`${styles.typographySecondary}`}>no wins yet</p>
-            ) : (
-              wins.map((win) => (
-                <div className={WinStyle} key={win.id}>
-                  <List
-                    sx={{
-                      width: "100%",
-                      maxWidth: 360,
-                    }}
-                  >
-                    <ListItem alignItems="flex-start">
-                      <ListItemAvatar>
-                        <IconButton
-                          aria-label="delete win"
-                          size={"small"}
-                          onClick={() => {
-                            deleteWin(win);
-                            handleDeleteWinClick();
-                          }}
-                        >
-                          <DeleteIcon fontSize="small" />
-                        </IconButton>
-                      </ListItemAvatar>
-                      <ListItemText
-                        primary={
-                          <>
-                            <p>{win.win_text}</p>
-                          </>
-                        }
-                        secondary={
-                          <>
-                            <p className={DateStyle}>
+        <View className={ContainerStyle}>
+          <Tooltip title="No wins yet">
+            <span>
+              <SecondaryButton
+                label={"open win jar"}
+                onClick={() => setIsWinJarOpen(true)}
+                disabled={!wins.length}
+                startIcon={<AutoAwesomeOutlinedIcon />}
+              />
+            </span>
+          </Tooltip>
+          <Modal
+            open={isWinJarOpen}
+            onClose={() => setIsWinJarOpen(false)}
+            closeAfterTransition
+            keepMounted
+          >
+            <Fade in={isWinJarOpen}>
+              <Box sx={modalStyle}>
+                <p className={HeaderStyle}>Your wins</p>
+                <div className={WinListStyle}>
+                  {!wins.length ? (
+                    <p className={`${styles.typographySecondary}`}>
+                      no wins yet
+                    </p>
+                  ) : (
+                    wins
+                      .map((win) => (
+                        <div key={win.id} className={WinStyle}>
+                          <div className={WinContentStyle}>
+                            <span className={DateStyle}>
                               {new Date(win.createdAt).toLocaleDateString()}
-                            </p>
-                          </>
-                        }
-                      />
-                    </ListItem>
-                  </List>
+                            </span>
+                            <span className={WinTextStyle}>{win.win_text}</span>
+                          </div>
+                          <IconButton
+                            aria-label="delete win"
+                            size={"small"}
+                            onClick={() => {
+                              deleteWin(win);
+                              handleDeleteWinClick();
+                            }}
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </div>
+                      ))
+                      .reverse()
+                  )}
                 </div>
-              ))
-            )}
-          </div>
+              </Box>
+            </Fade>
+          </Modal>
+          <Snackbar
+            open={isSuccessAlertVisible}
+            autoHideDuration={6000}
+            onClose={handleAlertClose}
+          >
+            <Alert
+              onClose={handleAlertClose}
+              severity="success"
+              sx={{ width: "100%" }}
+            >
+              {alertText}
+            </Alert>
+          </Snackbar>
         </View>
       </View>
     </>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -70,7 +70,7 @@ const Secondary = styled(Button)({
   },
   "&:active": {
     boxShadow: "none",
-    backgroundColor: styles.primaryAccentHex,
+    backgroundColor: styles.primaryAccent100Hex,
   },
   "&:focus": {
     boxShadow: "0 0 0 0.2rem rgba(0,123,255,.5)",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   endIcon?: JSX.Element;
   onClick?: () => void;
   type?: "submit" | "button" | "reset";
+  disabled?: boolean;
 }
 
 const Primary = styled(Button)({
@@ -39,6 +40,7 @@ export const PrimaryButton: React.FC<ButtonProps> = ({
   endIcon,
   type,
   onClick,
+  disabled,
 }: ButtonProps) => {
   return (
     <Primary
@@ -49,6 +51,7 @@ export const PrimaryButton: React.FC<ButtonProps> = ({
       endIcon={endIcon}
       type={type}
       onClick={onClick}
+      disabled={disabled}
     >
       {label}
     </Primary>
@@ -79,6 +82,7 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
   endIcon,
   type,
   onClick,
+  disabled,
 }: ButtonProps) => {
   return (
     <Secondary
@@ -89,6 +93,7 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
       endIcon={endIcon}
       type={type}
       onClick={onClick}
+      disabled={disabled}
     >
       {label}
     </Secondary>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -17,7 +17,6 @@ interface ButtonProps {
 const Primary = styled(Button)({
   boxShadow: "none",
   textTransform: "none",
-  border: "1px solid",
   borderRadius: "6px",
   backgroundColor: styles.primaryAccentHex,
   "&:hover": {
@@ -61,14 +60,17 @@ export const PrimaryButton: React.FC<ButtonProps> = ({
 const Secondary = styled(Button)({
   boxShadow: "none",
   textTransform: "none",
-  color: styles.secondaryHex,
+  border: "1px solid",
+  borderColor: styles.primaryAccentHex,
+  borderRadius: "6px",
+  color: styles.primaryAccentHex,
   "&:hover": {
-    backgroundColor: styles.secondaryHoverHex,
+    backgroundColor: styles.primaryAccent100Hex,
     boxShadow: "none",
   },
   "&:active": {
     boxShadow: "none",
-    backgroundColor: styles.secondaryHoverHex,
+    backgroundColor: styles.primaryAccentHex,
   },
   "&:focus": {
     boxShadow: "0 0 0 0.2rem rgba(0,123,255,.5)",
@@ -87,7 +89,7 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
   return (
     <Secondary
       name={name}
-      variant="text"
+      variant="outlined"
       size="large"
       startIcon={startIcon}
       endIcon={endIcon}
@@ -97,5 +99,47 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
     >
       {label}
     </Secondary>
+  );
+};
+
+const Link = styled(Button)({
+  boxShadow: "none",
+  textTransform: "none",
+  color: styles.secondaryHex,
+  "&:hover": {
+    backgroundColor: styles.secondaryHoverHex,
+    boxShadow: "none",
+  },
+  "&:active": {
+    boxShadow: "none",
+    backgroundColor: styles.secondaryHoverHex,
+  },
+  "&:focus": {
+    boxShadow: "0 0 0 0.2rem rgba(0,123,255,.5)",
+  },
+});
+
+export const LinkButton: React.FC<ButtonProps> = ({
+  name,
+  label,
+  startIcon,
+  endIcon,
+  type,
+  onClick,
+  disabled,
+}: ButtonProps) => {
+  return (
+    <Link
+      name={name}
+      variant="text"
+      size="large"
+      startIcon={startIcon}
+      endIcon={endIcon}
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {label}
+    </Link>
   );
 };

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -6,6 +6,8 @@ export interface TextFieldProps {
   label: string;
   name: string;
   isMultiline?: boolean;
+  value?: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => any;
 }
 
 const MUITextField = styled(TextField)({
@@ -32,6 +34,8 @@ export const TextFieldInput: React.FC<TextFieldProps> = ({
   name,
   label,
   isMultiline,
+  value,
+  onChange,
 }) => {
   return (
     <MUITextField
@@ -39,6 +43,8 @@ export const TextFieldInput: React.FC<TextFieldProps> = ({
       variant="outlined"
       multiline={isMultiline}
       name={name}
+      value={value}
+      onChange={onChange}
     />
   );
 };

--- a/src/stories/2-Components/Buttons.stories.tsx
+++ b/src/stories/2-Components/Buttons.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { IconButton } from "@mui/material";
-import { PrimaryButton, SecondaryButton } from "../../components/Button";
+import { PrimaryButton, LinkButton } from "../../components/Button";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 
@@ -16,7 +16,7 @@ export const Buttons = () => (
       endIcon={<AddOutlinedIcon />}
       type={"submit"}
     />
-    <SecondaryButton label={"sign out"} endIcon={<LogoutOutlinedIcon />} />
+    <LinkButton label={"sign out"} endIcon={<LogoutOutlinedIcon />} />
     <IconButton aria-label="delete win" size={"small"}>
       <DeleteIcon fontSize="small" />
     </IconButton>


### PR DESCRIPTION
- Move wins to behind a modal to avoid a long list of items appended on the main page 
- Disable button until text is entered to prevent sending an empty response
- Don't allow open win jar until a win is added, and show a tooltip over disabled button
- Add success toast notifications for when a win is successfully added and deleted
- Show wins from newest to oldest